### PR TITLE
chart: remove unneeded externalTraficPolicy from service

### DIFF
--- a/charts/brigade-cloudevents-gateway/templates/service.yaml
+++ b/charts/brigade-cloudevents-gateway/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "gateway.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
-  externalTrafficPolicy: Local
   ports:
   {{- if .Values.tls.enabled }}
   - port: 443


### PR DESCRIPTION
This was inadvertently copied from another chart that I used as a template to accelerate the creation of this one and it's causing some problems-- namely it seems to prevent the use of a service of type `ClusterIP` as this attribute is only applicable to services of types `NodePort` and `LoadBalancer`-- and even in those cases, we don't need it.