### PR TITLE
minor test improvements

### DIFF
--- a/golangci.yaml
+++ b/golangci.yaml
@@ -16,7 +16,6 @@ linters:
   - gocyclo
   - gofmt
   - goimports
-  - golint
   - gosec
   - govet
   - lll
@@ -24,6 +23,7 @@ linters:
   - misspell
   - nakedret
   - prealloc
+  - revive
   - unconvert
   - unparam
   - unused
@@ -61,9 +61,6 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/org/project
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
   govet:
     # report about shadowed variables
     check-shadowing: true

--- a/internal/cloudevents/service_test.go
+++ b/internal/cloudevents/service_test.go
@@ -12,13 +12,14 @@ import (
 )
 
 func TestNewService(t *testing.T) {
-	s := NewService( // nolint: forcetypeassert
+	s, ok := NewService(
 		// Totally unusable client that is enough to fulfill the dependencies for
 		// this test...
 		&coreTesting.MockEventsClient{
 			LogsClient: &coreTesting.MockLogsClient{},
 		},
 	).(*service)
+	require.True(t, ok)
 	require.NotNil(t, s.eventsClient)
 }
 


### PR DESCRIPTION
A follow up to #28 

This PR replaces a deprecated linter and also improves tests slightly by remediating a few linting issues instead of sweeping them under the rug.

This PR also fixes test cases where assertion functions took an `*httptest.ResponseRecorder` argument. `*http.Response`, which is more common and familiar type, is used instead. It should improve the overall readability of the tests.