### PR TITLE
use sdk v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/brigadecore/brigade-foundations v0.3.0
-	github.com/brigadecore/brigade/sdk/v2 v2.0.0-rc.1
+	github.com/brigadecore/brigade/sdk/v2 v2.0.0
 	github.com/cloudevents/sdk-go/v2 v2.4.1
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/brigadecore/brigade-foundations v0.3.0 h1:galsMzxSprURAEc2pxsmYJandiW4D+Npchx6ZiBIHkY=
 github.com/brigadecore/brigade-foundations v0.3.0/go.mod h1:edMgSJCUgfHN1RNGiiVOTRW4X4VykBLgssgWHPZK7Sg=
-github.com/brigadecore/brigade/sdk/v2 v2.0.0-rc.1 h1:VVGS/GOA1jSmEXTIOk54rf9GsqCxwosoulrA1OwC2xg=
-github.com/brigadecore/brigade/sdk/v2 v2.0.0-rc.1/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/U6bUAUtSLkgJcbOHIY=
+github.com/brigadecore/brigade/sdk/v2 v2.0.0 h1:RpApjVcSvuwuN5Sdjm4Vw9H5JWaxl/vZA6f3xC+cPp4=
+github.com/brigadecore/brigade/sdk/v2 v2.0.0/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/U6bUAUtSLkgJcbOHIY=
 github.com/cloudevents/sdk-go/v2 v2.4.1 h1:rZJoz9QVLbWQmnvLPDFEmv17Czu+CfSPwMO6lhJ72xQ=
 github.com/cloudevents/sdk-go/v2 v2.4.1/go.mod h1:MZiMwmAh5tGj+fPFvtHv9hKurKqXtdB9haJYMJ/7GJY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
This PR cuts over to using the GA SDK.

fwiw, I do not intend to continue upgrading the SDK every time there is a Brigade release. Now that we're at least using a stable/GA SDK, I will limit further upgrades of this nature to cases where there is true impetus such as a remediated bug a or a new feature we are in need of leveraging.