### PR TITLE
ci: do not publish edge images on merge to main

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -142,9 +142,6 @@ const publishChartJob = (event: Event, version: string) => {
   })
 }
 
-// Run the entire suite of tests WITHOUT publishing anything initially. If
-// EVERYTHING passes AND this was a push (merge, presumably) to the main branch,
-// then publish an "edge" image.
 events.on("brigade.sh/github", "ci:pipeline_requested", async event => {
   await new SerialGroup(
     new ConcurrentGroup( // Basic tests
@@ -154,10 +151,6 @@ events.on("brigade.sh/github", "ci:pipeline_requested", async event => {
     ),
     buildJob(event)
   ).run()
-  if (event.worker?.git?.ref == "main") {
-    // Push "edge" image
-    await pushJob(event).run()
-  }
 })
 
 // This event indicates a specific job is to be re-run.


### PR DESCRIPTION
For quite some time, we've published images tagged with a git sha and "edge" upon every merge to main -- the result being that we use up a _lot_ of storage on DockerHub. Most of these images are never pulled/used, as they _don't_ represent stable, officially released software. As I prepare for the _possibility_ of moving off of DockerHub for various reasons, I'm becoming more conscious of not using up registry space so indiscriminately.

This PR stops us from publishing "edge" images after each merge.