### PR TITLE
Dockerfile: cache go mods in their own layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ ARG TARGETOS
 ARG TARGETARCH
 ENV CGO_ENABLED=0
 
-WORKDIR /
-COPY . /
+WORKDIR /src
 COPY go.mod go.mod
 COPY go.sum go.sum
+RUN go mod download
+COPY . .
 
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o bin/cloudevents-gateway \
@@ -18,6 +19,6 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
 
 FROM gcr.io/distroless/static:nonroot as final
 
-COPY --from=builder /bin/ /brigade-cloudevents-gateway/bin/
+COPY --from=builder /src/bin/ /brigade-cloudevents-gateway/bin/
 
 ENTRYPOINT ["/brigade-cloudevents-gateway/bin/cloudevents-gateway"]


### PR DESCRIPTION
This PR caches resolved dependencies in their own layer to improve build time when built repeatedly -- i.e. during dev.