### PR TITLE
devx/docs: add auth details to contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,10 +62,35 @@ _before_ running `tilt up`:
      --source brigade.sh/cloudevents
    ```
 
+   > ⚠️&nbsp;&nbsp;Contributions that automate the creation and configuration of
+   > the service account setup are welcome.
+
+1. Edit the `tokens` section of `charts/brigade-cloudevents-gateway/values.yaml`
+   to map cloudevent sources to tokens (shared secrets) that clients can use to
+   authenticate to your gateway. See
+   [this section](./README.md#2-install-the-cloudevents-gateway) of `README.md`
+   for more information.
+
+   > ⚠️&nbsp;&nbsp;Take care not to include modifications to the `values.yaml`
+   > file in any PRs you open.
+
 You can then run `tilt up` to build and deploy this gateway from source.
 
-> ⚠️&nbsp;&nbsp;Contributions that automate the creation and configuration of
-> the service account setup are welcome.
+## Receiving Events Originating Locally
+
+You can send cloudevents from a local client to `http://localhost:31700/events`.
+The example below utilizes `curl`. Be sure to substitute an appropriate token
+from the previous section in the `Authorization` header.
+
+```shell
+$ curl -i -k -X POST \
+    -H "ce-specversion: 1.0" \
+    -H "ce-id: 1234-1234-1234" \
+    -H "ce-source: example/uri" \
+    -H "ce-type: example.type" \
+    -H "Authorization: Bearer MySharedSecret" \
+    http://localhost:31700/events
+```
 
 ## Receiving Events from External Services
 
@@ -88,8 +113,9 @@ of this:
    the applicable ngrok URL will be displayed in the gateway's logs in the Tilt
    UI.
 
-1. Use the ngrok URL from the previous step when configuring external services
-   to deliver cloudevents to your gateway.
+1. Use the ngrok URL from the previous step and token(s) (shared secrets) from
+   the [Running `tilt up` section](#running-tilt-up) when configuring external
+   services to deliver cloudevents to your gateway.
 
 > ⚠️&nbsp;&nbsp;We cannot guarantee that ngrok will work in all environments,
 > especially if you are behind a corporate firewall.


### PR DESCRIPTION
These details were missing from #64 