### PR TITLE
implement abuse protection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/brigadecore/brigade-foundations v0.3.0
 	github.com/brigadecore/brigade/sdk/v3 v3.0.0
-	github.com/cloudevents/sdk-go/v2 v2.4.1
+	github.com/cloudevents/sdk-go/v2 v2.10.0
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,14 +2,14 @@ github.com/brigadecore/brigade-foundations v0.3.0 h1:galsMzxSprURAEc2pxsmYJandiW
 github.com/brigadecore/brigade-foundations v0.3.0/go.mod h1:edMgSJCUgfHN1RNGiiVOTRW4X4VykBLgssgWHPZK7Sg=
 github.com/brigadecore/brigade/sdk/v3 v3.0.0 h1:jCjKQuoDYK8J+P2Zpuc/IQK/GKx0M678AbD0GgxOvcM=
 github.com/brigadecore/brigade/sdk/v3 v3.0.0/go.mod h1:Ow91x3wvUtkyMsV6hwbPtVZevrcHqoH0Pjh0OID4Sh0=
-github.com/cloudevents/sdk-go/v2 v2.4.1 h1:rZJoz9QVLbWQmnvLPDFEmv17Czu+CfSPwMO6lhJ72xQ=
-github.com/cloudevents/sdk-go/v2 v2.4.1/go.mod h1:MZiMwmAh5tGj+fPFvtHv9hKurKqXtdB9haJYMJ/7GJY=
+github.com/cloudevents/sdk-go/v2 v2.10.0 h1:sz0pbNBGh1iRspqLGe/2cXhDghZZpvNPHwKPucVbh+8=
+github.com/cloudevents/sdk-go/v2 v2.10.0/go.mod h1:GpCBmUj7DIRiDhVvsK5d6WCbgTWs8DxAWTRtAwQmIXs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
-github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -52,6 +52,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cloudevents/http/abuse_protection.go
+++ b/internal/cloudevents/http/abuse_protection.go
@@ -1,0 +1,78 @@
+package http
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	cloudHTTP "github.com/cloudevents/sdk-go/v2/protocol/http"
+)
+
+// ValidateEventSource responds to HTTP OPTIONS requests sent by a CloudEvents
+// 1.0 source as part of the spec's abuse protection scheme.
+func ValidateEventSource(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodOptions {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	headers := make(http.Header)
+	headers.Set("WebHook-Allowed-Origin", "*")
+	headers.Set(
+		"WebHook-Allowed-Rate",
+		strconv.Itoa(cloudHTTP.DefaultAllowedRate),
+	)
+	headers.Set("Allow", http.MethodPost)
+
+	// Complete the handshake asynchronously if a callback URL was provided...
+	if callbackURL :=
+		r.Header.Get("WebHook-Request-Callback"); callbackURL != "" {
+		// The spec is somewhat vague here. It says we can send either GET or POST,
+		// but it doesn't explicitly state that the receiver (the event source we're
+		// validating) has to accept both. To cover our bases and ensure
+		// compatibility with all CloudEvent 1.0-compatible event sources, we send
+		// both. If one of the two fails, it's logged and it's not a big deal.
+		//
+		// See https://github.com/cloudevents/spec/issues/1018
+		go executeSourceValidationCallback(http.MethodGet, callbackURL, headers)
+		go executeSourceValidationCallback(http.MethodPost, callbackURL, headers)
+		return
+	}
+
+	for k := range headers {
+		w.Header().Set(k, headers.Get(k))
+	}
+}
+
+func executeSourceValidationCallback(method, url string, headers http.Header) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		log.Printf(
+			"error preparing HTTP %s for validation callback URL %s: %s",
+			method,
+			url,
+			err,
+		)
+		return
+	}
+	for k := range headers {
+		req.Header.Set(k, headers.Get(k))
+	}
+	// Experience has revealed that if we don't wait for at least a little while
+	// before executing the callback, Azure Event Grid responds with a 200 as if
+	// everything is OK, but does NOT actually complete the handshake.
+	// Since we care about compatibility with Azure Event Grid, we'll tolerate
+	// this. And because these callbacks are specifically meant to facilitate
+	// asynchronous handshakes, this short delay really shouldn't cause any issue
+	// for OTHER CloudEvents 1.0-compatible event sources.
+	<-time.After(10 * time.Second)
+	if _, err = http.DefaultClient.Do(req); err != nil {
+		log.Printf(
+			"error executing HTTP %s for validation callback URL %s: %s",
+			method,
+			url,
+			err,
+		)
+	}
+}

--- a/internal/cloudevents/http/abuse_protection_test.go
+++ b/internal/cloudevents/http/abuse_protection_test.go
@@ -1,0 +1,165 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	cloudHTTP "github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEventSource(t *testing.T) {
+	// callbackReceiver extends *httptest.Server to add channels that can be used
+	// to assert that expected callbacks were received.
+	type callbackReceiver struct {
+		getCallbackCh  chan struct{}
+		postCallbackCh chan struct{}
+		*httptest.Server
+	}
+	testCases := []struct {
+		name  string
+		setup func(
+			context.Context,
+			*testing.T,
+		) (*http.Request, *callbackReceiver)
+		assertions func(
+			context.Context,
+			*testing.T,
+			*http.Response,
+			*callbackReceiver,
+		)
+	}{
+		{
+			name: "method is not OPTIONS",
+			setup: func(
+				_ context.Context,
+				t *testing.T,
+			) (*http.Request, *callbackReceiver) {
+				r, err := http.NewRequest(http.MethodGet, "/", nil)
+				require.NoError(t, err)
+				return r, nil
+			},
+			assertions: func(
+				_ context.Context,
+				t *testing.T,
+				r *http.Response,
+				_ *callbackReceiver,
+			) {
+				require.Equal(t, http.StatusMethodNotAllowed, r.StatusCode)
+			},
+		},
+		{
+			name: "WebHook-Request-Callback header NOT set",
+			// This tests a synchronous handshake
+			setup: func(
+				_ context.Context,
+				t *testing.T,
+			) (*http.Request, *callbackReceiver) {
+				r, err := http.NewRequest(http.MethodOptions, "/", nil)
+				require.NoError(t, err)
+				return r, nil
+			},
+			assertions: func(
+				_ context.Context,
+				t *testing.T,
+				r *http.Response,
+				_ *callbackReceiver,
+			) {
+				require.Equal(t, http.StatusOK, r.StatusCode)
+				require.Equal(t, "*", r.Header.Get("WebHook-Allowed-Origin"))
+				require.Equal(
+					t,
+					strconv.Itoa(cloudHTTP.DefaultAllowedRate),
+					r.Header.Get("WebHook-Allowed-Rate"),
+				)
+				require.Equal(t, http.MethodPost, r.Header.Get("Allow"))
+			},
+		},
+		{
+			name: "WebHook-Request-Callback header set",
+			// This tests an asynchronous handshake
+			setup: func(
+				ctx context.Context,
+				t *testing.T,
+			) (*http.Request, *callbackReceiver) {
+				s := &callbackReceiver{
+					getCallbackCh:  make(chan struct{}),
+					postCallbackCh: make(chan struct{}),
+				}
+				s.Server = httptest.NewServer(http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						switch r.Method {
+						case http.MethodGet:
+							// Indicate the GET callback was received
+							select {
+							case s.getCallbackCh <- struct{}{}:
+							case <-ctx.Done():
+							}
+						case http.MethodPost:
+							// Indicate the POST callback was received
+							select {
+							case s.postCallbackCh <- struct{}{}:
+							case <-ctx.Done():
+							}
+						default:
+							require.FailNow(
+								t,
+								fmt.Sprintf(
+									"callback received with unexpected method %s",
+									r.Method,
+								),
+							)
+						}
+					},
+				))
+				r, err := http.NewRequest(http.MethodOptions, "/", nil)
+				require.NoError(t, err)
+				r.Header.Set("WebHook-Request-Callback", s.URL)
+				return r, s
+			},
+			assertions: func(
+				ctx context.Context,
+				t *testing.T,
+				r *http.Response,
+				s *callbackReceiver,
+			) {
+				require.Equal(t, http.StatusOK, r.StatusCode)
+				require.Empty(t, r.Header.Get("WebHook-Allowed-Origin"))
+				require.Empty(t, r.Header.Get("WebHook-Allowed-Rate"))
+				require.Empty(t, r.Header.Get("Allow"))
+				// Validate that the GET callback was received
+				select {
+				case <-s.getCallbackCh:
+				case <-ctx.Done():
+					require.FailNow(t, "did not receive GET callback by deadline")
+				}
+				// Validate that the POST callback was received
+				select {
+				case <-s.postCallbackCh:
+				case <-ctx.Done():
+					require.FailNow(t, "did not receive POST callback by deadline")
+				}
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// One test case involves an asynchronous handshake that takes 10 seconds.
+			// For good measure, we're setting a deadline of 12 seconds.
+			ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+			defer cancel()
+			r, s := testCase.setup(ctx, t)
+			if s != nil {
+				defer s.Close()
+			}
+			rr := httptest.NewRecorder()
+			ValidateEventSource(rr, r)
+			testCase.assertions(ctx, t, rr.Result(), s)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/brigadecore/brigade-cloudevents-gateway/internal/cloudevents"
+	ourCloudHTTP "github.com/brigadecore/brigade-cloudevents-gateway/internal/cloudevents/http" // nolint: lll
 	libHTTP "github.com/brigadecore/brigade-foundations/http"
 	"github.com/brigadecore/brigade-foundations/signals"
 	"github.com/brigadecore/brigade-foundations/version"
@@ -37,14 +38,7 @@ func main() {
 
 	var cloudEventsHandler *client.EventReceiver
 	{
-		proto, err := cloudHTTP.New(
-			cloudHTTP.WithDefaultOptionsHandlerFunc(
-				[]string{http.MethodPost},
-				cloudHTTP.DefaultAllowedRate,
-				[]string{"*"},
-				true,
-			),
-		)
+		proto, err := cloudHTTP.New()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -74,7 +68,7 @@ func main() {
 		).Methods(http.MethodPost)
 		router.HandleFunc(
 			"/events",
-			cloudEventsHandler.ServeHTTP, // No auth filter for OPTIONS requests
+			ourCloudHTTP.ValidateEventSource, // No auth filter for OPTIONS requests
 		).Methods(http.MethodOptions)
 		router.HandleFunc("/healthz", libHTTP.Healthz).Methods(http.MethodGet)
 		serverConfig, err := serverConfig()


### PR DESCRIPTION
Custom implementation of [abuse protection](https://github.com/cloudevents/spec/blob/v1.0/http-webhook.md#4-abuse-protection) -- specifically the async source validation / handshake.

This allows us to account for some ambiguity in the spec and to make a modest concession to account for strange Azure Event Grid behavior.

If an event source is truly CloudEvents 1.0-compliant, it won't work with this gateway _without_ this feature, so I am going as far as to count this as a bug fix.