### PR TITLE
state brigade v2.6.0 as minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prerequisites:
 
 * A Kubernetes cluster:
     * For which you have the `admin` cluster role
-    * That is already running Brigade 2
+    * That is already running Brigade 2.6.0+
     * Capable of provisioning a _public IP address_ for a service of type
       `LoadBalancer`. (This means you won't have much luck running the gateway
       locally in the likes of kind or minikube unless you're able and willing to


### PR DESCRIPTION
Fixes #75 

Note Brigade v2.6.0 isn't out yet. We'll release it _before_ this gateway goes GA.